### PR TITLE
Fix missing home page URL

### DIFF
--- a/pyshop/urls.py
+++ b/pyshop/urls.py
@@ -15,8 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.shortcuts import redirect
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('products/', include('products.urls'))
+    path('products/', include('products.urls')),
+    path('', lambda request: redirect('/products/')),
 ]


### PR DESCRIPTION
## Summary
- redirect requests to `/` to the products listing

## Testing
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ee7f444c083248483ee4ebfcf42e0