### PR TITLE
Fix home route

### DIFF
--- a/pyshop/urls.py
+++ b/pyshop/urls.py
@@ -18,5 +18,6 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('products.urls')),
     path('products/', include('products.urls'))
 ]


### PR DESCRIPTION
## Summary
- route the root URL to `products.urls`

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684ee9cdbd2483248516a0dff2a430e3