### PR TITLE
Implement AJAX wishlist/cart actions

### DIFF
--- a/products/templates/index.html
+++ b/products/templates/index.html
@@ -18,7 +18,8 @@
 							<h5 class="card-title">{{ product.name }} - <strong>${{ product.price }}</strong></h5>
 							<p class="card-text">Some quick example text to build on the card title and make up the bulk of the
 								card's content.</p>
-							<a href="#" class="btn btn-primary">Add to cart</a>
+                                                        <a href="#" class="btn btn-primary add-to-cart" data-id="{{ product.id }}">Add to cart</a>
+                                                        <a href="#" class="btn btn-secondary add-to-wishlist" data-id="{{ product.id }}" style="margin-left:5px;">Wishlist</a>
 						</div>
 					</div>
 				</div>

--- a/products/urls.py
+++ b/products/urls.py
@@ -4,5 +4,7 @@ from . import views
 
 urlpatterns = [
     path('', views.index),
-    path('new/', views.new)
+    path('new/', views.new),
+    path('add-to-cart/', views.add_to_cart, name='add_to_cart'),
+    path('add-to-wishlist/', views.add_to_wishlist, name='add_to_wishlist')
 ]

--- a/products/views.py
+++ b/products/views.py
@@ -1,5 +1,6 @@
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
+from django.views.decorators.http import require_POST
 from .models import Product
 
 
@@ -13,4 +14,32 @@ def index(request):
 
 def new(request):
     return HttpResponse('Welcome to PyShop New Arrivals')
+
+
+@require_POST
+def add_to_cart(request):
+    product_id = request.POST.get('product_id')
+    if not product_id:
+        return JsonResponse({'success': False, 'message': 'No product id'})
+
+    cart = request.session.get('cart', [])
+    if product_id not in cart:
+        cart.append(product_id)
+        request.session['cart'] = cart
+
+    return JsonResponse({'success': True, 'cart_count': len(cart)})
+
+
+@require_POST
+def add_to_wishlist(request):
+    product_id = request.POST.get('product_id')
+    if not product_id:
+        return JsonResponse({'success': False, 'message': 'No product id'})
+
+    wishlist = request.session.get('wishlist', [])
+    if product_id not in wishlist:
+        wishlist.append(product_id)
+        request.session['wishlist'] = wishlist
+
+    return JsonResponse({'success': True, 'wishlist_count': len(wishlist)})
 

--- a/pyshop/settings.py
+++ b/pyshop/settings.py
@@ -121,3 +121,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static')
+]
+

--- a/static/js/cart.js
+++ b/static/js/cart.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', () => {
+    function getCookie(name) {
+        let cookieValue = null;
+        if (document.cookie && document.cookie !== '') {
+            const cookies = document.cookie.split(';');
+            for (let i = 0; i < cookies.length; i++) {
+                const cookie = cookies[i].trim();
+                if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        return cookieValue;
+    }
+
+    function sendPost(url, productId, callback) {
+        fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-CSRFToken': getCookie('csrftoken')
+            },
+            body: new URLSearchParams({ product_id: productId })
+        })
+            .then(resp => resp.json())
+            .then(callback)
+            .catch(err => console.error('Request failed', err));
+    }
+
+    document.querySelectorAll('.add-to-cart').forEach(btn => {
+        btn.addEventListener('click', e => {
+            e.preventDefault();
+            const id = btn.dataset.id;
+            sendPost('/products/add-to-cart/', id, data => {
+                if (data.success) {
+                    alert('Added to cart');
+                }
+            });
+        });
+    });
+
+    document.querySelectorAll('.add-to-wishlist').forEach(btn => {
+        btn.addEventListener('click', e => {
+            e.preventDefault();
+            const id = btn.dataset.id;
+            sendPost('/products/add-to-wishlist/', id, data => {
+                if (data.success) {
+                    alert('Added to wishlist');
+                }
+            });
+        });
+    });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!doctype html>
 <html lang="en">
   <head>
@@ -56,5 +57,6 @@
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+    <script src="{% static 'js/cart.js' %}"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load static assets in base template
- include cart.js for asynchronous cart/wishlist requests
- expose `add-to-cart` and `add-to-wishlist` Django views
- add buttons on the products list
- add staticfiles path in settings

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684f0877410c832484c4e6b05810f8ee