### PR TITLE
Add unit tests and document coverage

### DIFF
--- a/UUT.md
+++ b/UUT.md
@@ -1,0 +1,16 @@
+# Units Under Test
+
+This project includes Django applications with basic e-commerce functionality.
+The following units are covered by tests:
+
+- `Product` model: verifies product creation and field assignments.
+- `index` view: ensures the index page renders with products listed.
+- `new` view: checks the new arrivals view returns the expected message.
+
+The test suite can be run with:
+
+```bash
+python manage.py test
+```
+
+Test output from a recent run is stored in `test_results.md`.

--- a/products/tests.py
+++ b/products/tests.py
@@ -1,3 +1,39 @@
 from django.test import TestCase
+from django.urls import reverse
+from .models import Product
 
-# Create your tests here.
+class ProductModelTest(TestCase):
+    def test_create_product(self):
+        product = Product.objects.create(
+            name='Test Product',
+            price=9.99,
+            stock=10,
+            image_url='http://example.com/image.jpg'
+        )
+        self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(product.name, 'Test Product')
+        self.assertEqual(product.price, 9.99)
+        self.assertEqual(product.stock, 10)
+        self.assertEqual(product.image_url, 'http://example.com/image.jpg')
+
+class IndexViewTest(TestCase):
+    def setUp(self):
+        Product.objects.create(
+            name='Index Product',
+            price=1.0,
+            stock=5,
+            image_url='http://example.com/img.jpg'
+        )
+
+    def test_index_view_displays_products(self):
+        response = self.client.get('/products/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'index.html')
+        self.assertIn('products', response.context)
+        self.assertEqual(len(response.context['products']), 1)
+
+class NewViewTest(TestCase):
+    def test_new_view_returns_message(self):
+        response = self.client.get('/products/new/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Welcome to PyShop New Arrivals')

--- a/test_results.md
+++ b/test_results.md
@@ -1,0 +1,16 @@
+Creating test database for alias 'default'...
+System check identified some issues:
+
+WARNINGS:
+products.Offer: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
+	HINT: Configure the DEFAULT_AUTO_FIELD setting or the ProductsConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
+products.Product: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
+	HINT: Configure the DEFAULT_AUTO_FIELD setting or the ProductsConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
+
+System check identified 2 issues (0 silenced).
+...
+----------------------------------------------------------------------
+Ran 3 tests in 0.008s
+
+OK
+Destroying test database for alias 'default'...


### PR DESCRIPTION
## Summary
- add unit tests for the Django `products` app
- document tested units in `UUT.md`
- record test output in `test_results.md`

## Testing
- `venv/bin/python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684f0bef7ee08324b4da757db3f989d6