### PR TITLE
Fix default primary key warnings

### DIFF
--- a/products/apps.py
+++ b/products/apps.py
@@ -2,4 +2,5 @@ from django.apps import AppConfig
 
 
 class ProductsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
     name = 'products'

--- a/pyshop/settings.py
+++ b/pyshop/settings.py
@@ -123,3 +123,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Specify BigAutoField as the default primary key field type to avoid
+# auto-created primary key warnings in Django 3.2+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'


### PR DESCRIPTION
## Summary
- set default primary key to BigAutoField in settings
- specify default_auto_field for `products` app

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684f382c51e88324858602c4b2a64f0e